### PR TITLE
Refactored testing with ginkgo framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,18 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/onsi/ginkgo/v2 v2.1.4
+	github.com/onsi/gomega v1.19.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+)
+
+require (
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
+	golang.org/x/text v0.3.7 // indirect
 )
 
 replace fybrik.io/openmetadata-connector/datacatalog-go => ./auto-generated/api

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
+github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
+github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -253,6 +257,8 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -260,6 +266,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/openmetadata-connector-core/openmetadata_connector_test.go
+++ b/pkg/openmetadata-connector-core/openmetadata_connector_test.go
@@ -2,18 +2,19 @@ package openapiconnectorcore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http/httptest"
 	"os"
-	"reflect"
 	"testing"
 
-	"fybrik.io/fybrik/pkg/logging"
-	"github.com/fatih/structs"
+	structs "github.com/fatih/structs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	zerolog "github.com/rs/zerolog"
 
+	"fybrik.io/fybrik/pkg/logging"
+	models "fybrik.io/openmetadata-connector/datacatalog-go-models"
 	api "fybrik.io/openmetadata-connector/datacatalog-go/go"
 	vault "fybrik.io/openmetadata-connector/pkg/vault"
 )
@@ -23,152 +24,84 @@ func TestOpenApiConnectorCore(t *testing.T) {
 	RunSpecs(t, "openApiConnectorCore Suite")
 }
 
-var _ = Describe("Vault and OM connector", func() {
+var _ = Describe("Vault and OM connector", Ordered, func() {
+	var logger zerolog.Logger
+	var err error
+	var jwtFile *os.File
+	var n int
+	var vaultConf map[interface{}]interface{}
+	var mockOMServer *httptest.Server
 	BeforeEach(func() {
-		teardownSuite := setupSuite()
+		logger = logging.LogInit(logging.CONNECTOR, "OpenMetadata Connector Tests")
+		logger.Trace().Msg("Setting up OM Connector test suite")
+		jwtFile, err = ioutil.TempFile("/tmp", "jwt")
+		Expect(err).ToNot(HaveOccurred())
+		n, err = jwtFile.WriteString(TestJWT)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(TestJWT)))
+		mockVaultServer := createMockVaultServer()
+		mockOMServer = createMockOMServer()
+
+		// populate vault configuration
+		vaultConf = make(map[interface{}]interface{})
+		vaultConf[Address] = mockVaultServer.URL
+		vaultConf[JwtFilePath] = jwtFile.Name()
+		vaultConf[AuthPath] = TestAuthPath
+		vaultConf[Role] = FybrikLowerCase
 		DeferCleanup(func() {
-			teardownSuite()
+			err = os.Remove(jwtFile.Name())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 	Describe("Vault credentials retrieval flow", Ordered, func() {
 		var token string
 		var err error
 		var secret []byte
-		vaultClient := vault.NewVaultClient(vaultConf, &logger)
-		It("should generate a vaild token", func() {
+		var vaultClient vault.VaultClient
+		It("should receive a vaild token", func() {
+			vaultClient = vault.NewVaultClient(vaultConf, &logger)
 			token, err = vaultClient.GetToken()
-			Expect(token).To(Equal(TestToken))
 			Expect(err).ToNot(HaveOccurred())
+			Expect(token).To(Equal(TestToken))
 		})
-		It("should generate a vaild secret", func() {
+		It("should receive a vaild secret", func() {
 			secret, err = vaultClient.GetSecret(token, TestPathInVault)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("should generate valid access and secret keys", func() {
+		It("should receive vaild access and secret keys", func() {
 			accessKey, secretKey, err := vaultClient.ExtractS3CredentialsFromSecret(secret)
 			Expect(accessKey).To(Equal(TestAccessKey))
 			Expect(secretKey).To(Equal(TestSecretKey))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
-	Describe("Connector creating and getting assesets", Ordered, func() {
-		conf := make(map[interface{}]interface{})
-		conf["openmetadata_endpoint"] = mockOMServer.URL
-		conf["vault"] = vaultConf
-		servicer := NewOpenMetadataAPIService(conf, &logger)
-		ctx := context.Background()
-		createAssetRequest, getAssetResponse := getCreateAssetRequestAndReponse()
-		response, err := servicer.CreateAsset(ctx, TestConnectorCredentials, createAssetRequest)
-		Expect(err).ToNot(HaveOccurred())
-
-		assetID := fmt.Sprintf("%s.%s.%s.%s", TestDatabaseService, TestDatabase, TestBucket, TestObjectName)
-		// check the asset ID in the response
-		responseStr := string(mustAsJSON(t, response.Body))
-
-		if responseStr != fmt.Sprintf("{\"assetID\":%q}", assetID) {
-			t.Error(errors.New("unexpected response from asset creation"))
-		}
-
-		response, err = servicer.GetAssetInfo(ctx, TestConnectorCredentials, &api.GetAssetRequest{AssetID: assetID, OperationType: "read"})
-		if err != nil {
-			t.Error(err)
-		}
-
-		responseMap := structs.Map(response.Body)
-		expectedMap := structs.Map(getAssetResponse)
-
-		if !reflect.DeepEqual(responseMap, expectedMap) {
-			t.Error("Test failed. getAssetInfo response not as expected")
-		}
+	Describe("Connector creating assesets and getting their info", Ordered, func() {
+		var getAssetResponse *models.GetAssetResponse
+		var createAssetRequest *models.CreateAssetRequest
+		var response api.ImplResponse
+		var servicer OpenMetadataAPIServicer
+		var assetID string
+		var ctx context.Context
+		It("should create an asset and receive a vaild response", func() {
+			conf := make(map[interface{}]interface{})
+			conf["openmetadata_endpoint"] = mockOMServer.URL
+			conf["vault"] = vaultConf
+			servicer = NewOpenMetadataAPIService(conf, &logger)
+			ctx = context.Background()
+			createAssetRequest, getAssetResponse = getCreateAssetRequestAndReponse()
+			response, err = servicer.CreateAsset(ctx, TestConnectorCredentials, createAssetRequest)
+			Expect(err).ToNot(HaveOccurred())
+			assetID = fmt.Sprintf("%s.%s.%s.%s", TestDatabaseService, TestDatabase, TestBucket, TestObjectName)
+			// check the asset ID in the response
+			responseStr := string(mustAsJSON(response.Body))
+			Expect(responseStr).To(Equal(fmt.Sprintf("{\"assetID\":%q}", assetID)))
+		})
+		It("should get the asset info", func() {
+			response, err = servicer.GetAssetInfo(ctx, TestConnectorCredentials, &api.GetAssetRequest{AssetID: assetID, OperationType: "read"})
+			Expect(err).ToNot(HaveOccurred())
+			responseMap := structs.Map(response.Body)
+			expectedMap := structs.Map(getAssetResponse)
+			Expect(responseMap).To(Equal(expectedMap))
+		})
 	})
 })
-
-func setupSuite() func() {
-	logger = logging.LogInit(logging.CONNECTOR, "OpenMetadata Connector Tests")
-	logger.Trace().Msg("Setting up OM Connector test suite")
-
-	var err error
-	jwtFile, err = ioutil.TempFile("/tmp", "jwt")
-	if err != nil {
-		logger.Fatal().Msg("failed to create temporary file")
-	}
-	n, err := jwtFile.WriteString(TestJWT)
-	if err != nil || n != len(TestJWT) {
-		logger.Fatal().Msg("failed to write to temporary file")
-	}
-
-	mockVaultServer = createMockVaultServer()
-	mockOMServer = createMockOMServer()
-
-	// populate vault configuration
-	vaultConf = make(map[interface{}]interface{})
-	vaultConf[Address] = mockVaultServer.URL
-	vaultConf[JwtFilePath] = jwtFile.Name()
-	vaultConf[AuthPath] = TestAuthPath
-	vaultConf[Role] = FybrikLowerCase
-
-	// Return a function to teardown the test
-	return func() {
-		logger.Trace().Msg("Tearing down OM Connector test suite")
-		os.Remove(jwtFile.Name())
-	}
-}
-
-func TestVault(t *testing.T) {
-	teardownSuite := setupSuite(t)
-	defer teardownSuite()
-
-	vaultClient := vault.NewVaultClient(vaultConf, &logger)
-
-	token, err := vaultClient.GetToken()
-	if err != nil || token != TestToken {
-		t.Error(err)
-	}
-
-	secret, err := vaultClient.GetSecret(token, TestPathInVault)
-	if err != nil {
-		t.Error(err)
-	}
-
-	accessKey, secretKey, err := vaultClient.ExtractS3CredentialsFromSecret(secret)
-	if err != nil || accessKey != TestAccessKey || secretKey != TestSecretKey {
-		t.Error(err)
-	}
-}
-
-func TestCreateAndGetAsset(t *testing.T) {
-	teardownSuite := setupSuite(t)
-	defer teardownSuite()
-
-	conf := make(map[interface{}]interface{})
-	conf["openmetadata_endpoint"] = mockOMServer.URL
-	conf["vault"] = vaultConf
-	servicer := NewOpenMetadataAPIService(conf, &logger)
-
-	ctx := context.Background()
-	createAssetRequest, getAssetResponse := getCreateAssetRequestAndReponse()
-	response, err := servicer.CreateAsset(ctx, TestConnectorCredentials, createAssetRequest)
-	if err != nil {
-		t.Error(err)
-	}
-
-	assetID := fmt.Sprintf("%s.%s.%s.%s", TestDatabaseService, TestDatabase, TestBucket, TestObjectName)
-
-	// check the asset ID in the response
-	responseStr := string(mustAsJSON(t, response.Body))
-	if responseStr != fmt.Sprintf("{\"assetID\":%q}", assetID) {
-		t.Error(errors.New("unexpected response from asset creation"))
-	}
-
-	response, err = servicer.GetAssetInfo(ctx, TestConnectorCredentials, &api.GetAssetRequest{AssetID: assetID, OperationType: "read"})
-	if err != nil {
-		t.Error(err)
-	}
-
-	responseMap := structs.Map(response.Body)
-	expectedMap := structs.Map(getAssetResponse)
-
-	if !reflect.DeepEqual(responseMap, expectedMap) {
-		t.Error("Test failed. getAssetInfo response not as expected")
-	}
-}

--- a/pkg/openmetadata-connector-core/openmetadata_connector_test.go
+++ b/pkg/openmetadata-connector-core/openmetadata_connector_test.go
@@ -11,12 +11,79 @@ import (
 
 	"fybrik.io/fybrik/pkg/logging"
 	"github.com/fatih/structs"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	api "fybrik.io/openmetadata-connector/datacatalog-go/go"
 	vault "fybrik.io/openmetadata-connector/pkg/vault"
 )
 
-func setupSuite(t *testing.T) func() {
+func TestOpenApiConnectorCore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "openApiConnectorCore Suite")
+}
+
+var _ = Describe("Vault and OM connector", func() {
+	BeforeEach(func() {
+		teardownSuite := setupSuite()
+		DeferCleanup(func() {
+			teardownSuite()
+		})
+	})
+	Describe("Vault credentials retrieval flow", Ordered, func() {
+		var token string
+		var err error
+		var secret []byte
+		vaultClient := vault.NewVaultClient(vaultConf, &logger)
+		It("should generate a vaild token", func() {
+			token, err = vaultClient.GetToken()
+			Expect(token).To(Equal(TestToken))
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should generate a vaild secret", func() {
+			secret, err = vaultClient.GetSecret(token, TestPathInVault)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should generate valid access and secret keys", func() {
+			accessKey, secretKey, err := vaultClient.ExtractS3CredentialsFromSecret(secret)
+			Expect(accessKey).To(Equal(TestAccessKey))
+			Expect(secretKey).To(Equal(TestSecretKey))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+	Describe("Connector creating and getting assesets", Ordered, func() {
+		conf := make(map[interface{}]interface{})
+		conf["openmetadata_endpoint"] = mockOMServer.URL
+		conf["vault"] = vaultConf
+		servicer := NewOpenMetadataAPIService(conf, &logger)
+		ctx := context.Background()
+		createAssetRequest, getAssetResponse := getCreateAssetRequestAndReponse()
+		response, err := servicer.CreateAsset(ctx, TestConnectorCredentials, createAssetRequest)
+		Expect(err).ToNot(HaveOccurred())
+
+		assetID := fmt.Sprintf("%s.%s.%s.%s", TestDatabaseService, TestDatabase, TestBucket, TestObjectName)
+		// check the asset ID in the response
+		responseStr := string(mustAsJSON(t, response.Body))
+
+		if responseStr != fmt.Sprintf("{\"assetID\":%q}", assetID) {
+			t.Error(errors.New("unexpected response from asset creation"))
+		}
+
+		response, err = servicer.GetAssetInfo(ctx, TestConnectorCredentials, &api.GetAssetRequest{AssetID: assetID, OperationType: "read"})
+		if err != nil {
+			t.Error(err)
+		}
+
+		responseMap := structs.Map(response.Body)
+		expectedMap := structs.Map(getAssetResponse)
+
+		if !reflect.DeepEqual(responseMap, expectedMap) {
+			t.Error("Test failed. getAssetInfo response not as expected")
+		}
+	})
+})
+
+func setupSuite() func() {
 	logger = logging.LogInit(logging.CONNECTOR, "OpenMetadata Connector Tests")
 	logger.Trace().Msg("Setting up OM Connector test suite")
 
@@ -30,8 +97,8 @@ func setupSuite(t *testing.T) func() {
 		logger.Fatal().Msg("failed to write to temporary file")
 	}
 
-	mockVaultServer = createMockVaultServer(t)
-	mockOMServer = createMockOMServer(t)
+	mockVaultServer = createMockVaultServer()
+	mockOMServer = createMockOMServer()
 
 	// populate vault configuration
 	vaultConf = make(map[interface{}]interface{})

--- a/pkg/openmetadata-connector-core/openmetadata_connector_test_helper.go
+++ b/pkg/openmetadata-connector-core/openmetadata_connector_test_helper.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	structs "github.com/fatih/structs"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint
+	. "github.com/onsi/gomega"    //nolint
 	zerolog "github.com/rs/zerolog"
 
 	client "fybrik.io/openmetadata-connector/datacatalog-go-client"
@@ -378,7 +378,7 @@ func handlePostMockOMServer(r *http.Request,
 }
 
 // returns a mock OM server, which handles select GET, POST, PUT, and PATCH requests
-func createMockOMServer() *httptest.Server { //nolint
+func createMockOMServer() *httptest.Server {
 	By("opreating a mock OM server")
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var response map[string]interface{}

--- a/pkg/openmetadata-connector-core/openmetadata_connector_test_helper.go
+++ b/pkg/openmetadata-connector-core/openmetadata_connector_test_helper.go
@@ -2,16 +2,16 @@ package openapiconnectorcore
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
-	"testing"
 
 	structs "github.com/fatih/structs"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	zerolog "github.com/rs/zerolog"
 
 	client "fybrik.io/openmetadata-connector/datacatalog-go-client"
@@ -132,58 +132,42 @@ func getCreateAssetRequestAndReponse() (*models.CreateAssetRequest, *models.GetA
 	return createAssetRequest, getAssetResponse
 }
 
-func mustAsJSON(t *testing.T, in interface{}) []byte {
+func mustAsJSON(in interface{}) []byte {
 	result, err := json.Marshal(in)
-	if err != nil {
-		t.Fatal(err)
-	}
+	Expect(err).ToNot(HaveOccurred())
 	return result
 }
 
 // Code for mock vault server. Handles both a request for a token, and a request for a secret
-func createMockVaultServer(t *testing.T) *httptest.Server {
+func createMockVaultServer() *httptest.Server {
+	By("opreating a mock Vault server")
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Error(err)
-			return
-		}
-
-		if r.Method == http.MethodPost && r.RequestURI == "/v1/auth/"+TestAuthPath+"/login" {
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r.Method).To(SatisfyAny(Equal(http.MethodPost), Equal(http.MethodGet)))
+		if r.Method == http.MethodPost {
+			By("receving a Post request")
+			Expect(r.RequestURI).To(Equal("/v1/auth/" + TestAuthPath + "/login"))
 			requestMap := make(map[string]interface{})
 			err = json.Unmarshal(requestBytes, &requestMap)
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			if (requestMap[Role].(string) != FybrikLowerCase) ||
-				(requestMap[JWT].(string) != TestJWT) {
-				t.Error(errors.New("unexpected request format"))
-				return
-			}
-
+			Expect(err).ToNot(HaveOccurred())
+			Expect(requestMap[Role].(string)).To(Equal(FybrikLowerCase))
+			Expect(requestMap[JWT].(string)).To(Equal(TestJWT))
 			response := map[string]interface{}{
 				RequestID: ZeroUUID,
 				Auth: map[string]interface{}{
 					ClientToken: TestToken,
 				},
 			}
-
-			responseBytes := mustAsJSON(t, response)
-
+			responseBytes := mustAsJSON(response)
 			w.Header().Add(ContentType, ApplicationJSON)
 			_, err = w.Write(responseBytes)
-			if err != nil {
-				t.Error(err)
-			}
-
+			Expect(err).ToNot(HaveOccurred())
 			return
 		}
-
 		if r.Method == http.MethodGet {
-			if r.Header.Get("X-Vault-Token") != TestToken {
-				t.Error(err)
-			}
+			By("receving a Get request")
+			Expect(r.Header.Get("X-Vault-Token")).To(Equal(TestToken))
 			logger.Trace().Msg("About to mock response secret request")
 			response := map[string]interface{}{
 				Data: map[string]interface{}{
@@ -192,17 +176,13 @@ func createMockVaultServer(t *testing.T) *httptest.Server {
 				},
 			}
 
-			responseBytes := mustAsJSON(t, response)
+			responseBytes := mustAsJSON(response)
 
 			w.Header().Add(ContentType, ApplicationJSON)
 			_, err = w.Write(responseBytes)
-			if err != nil {
-				t.Error(err)
-			}
-
+			Expect(err).ToNot(HaveOccurred())
 			return
 		}
-		t.Fatal("unexpected request")
 	}))
 
 	return svr
@@ -315,7 +295,7 @@ func patchTable(table *client.Table, patchArray []interface{}) bool { //nolint
 }
 
 // handle mock OM server GET requests
-func handleGetMockOMServer(t *testing.T, r *http.Request) (map[string]interface{}, int) {
+func handleGetMockOMServer(r *http.Request) (map[string]interface{}, int) {
 	if strings.HasPrefix(r.RequestURI, "/v1/metadata/types?category=entity") {
 		var types []interface{}
 		types = append(types, map[string]interface{}{FullyQualifiedName: "table", ID: "1"})
@@ -360,17 +340,15 @@ func handleGetMockOMServer(t *testing.T, r *http.Request) (map[string]interface{
 		return structs.Map(service), 0
 	}
 
-	t.Fatalf("unrecognized GET request")
 	return nil, http.StatusInternalServerError
 }
 
 // handle mock OM server POST requests
-func handlePostMockOMServer(t *testing.T, r *http.Request,
+func handlePostMockOMServer(r *http.Request,
 	requestMap map[string]interface{}) (map[string]interface{}, int) {
 	if r.RequestURI == "/v1/tags" {
 		return map[string]interface{}{}, 0
 	}
-
 	if r.RequestURI == DatabaseServicesURI {
 		// keep the connection information in the mock data catalog
 		service := constructDataBaseServiceStruct(requestMap)
@@ -379,7 +357,6 @@ func handlePostMockOMServer(t *testing.T, r *http.Request,
 		}
 		mockDataCatalog[DatabaseService] = service
 	}
-
 	if r.RequestURI == TablesURI {
 		table, ok := constructTableStruct(requestMap)
 		if !ok {
@@ -388,7 +365,6 @@ func handlePostMockOMServer(t *testing.T, r *http.Request,
 		mockDataCatalog[ZeroUUID] = table
 		return structs.Map(table), 0
 	}
-
 	if r.RequestURI == DatabaseServicesURI ||
 		r.RequestURI == "/v1/services/ingestionPipelines" ||
 		r.RequestURI == "/v1/databases" ||
@@ -398,73 +374,61 @@ func handlePostMockOMServer(t *testing.T, r *http.Request,
 			ID:                 ZeroUUID,
 			FullyQualifiedName: TestDatabaseService}, 0
 	}
-
-	t.Fatalf("unrecognized POST request")
 	return nil, http.StatusInternalServerError
 }
 
 // returns a mock OM server, which handles select GET, POST, PUT, and PATCH requests
-func createMockOMServer(t *testing.T) *httptest.Server { //nolint
+func createMockOMServer() *httptest.Server { //nolint
+	By("opreating a mock OM server")
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var response map[string]interface{}
 		var statusCode int
-
 		requestBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatal(err)
-			return
-		}
-
+		Expect(err).ToNot(HaveOccurred())
 		requestMap := make(map[string]interface{})
 		var requestArr []interface{}
 		if len(requestBytes) > 0 {
 			err = json.Unmarshal(requestBytes, &requestMap)
 			if err != nil {
 				err = json.Unmarshal(requestBytes, &requestArr)
-				if err != nil {
-					t.Fatalf(string(requestBytes))
-					return
-				}
+				Expect(err).ToNot(HaveOccurred())
 			}
 		}
-
+		Expect(r.Method).To(SatisfyAny(Equal(http.MethodGet), Equal(http.MethodPost), Equal(http.MethodPut), Equal(http.MethodPatch)))
 		if r.Method == http.MethodGet {
-			response, statusCode = handleGetMockOMServer(t, r)
+			By("receving a Get request to the OM server")
+			response, statusCode = handleGetMockOMServer(r)
+			Expect(statusCode).ToNot(Equal(http.StatusInternalServerError))
 			if statusCode != 0 {
 				w.WriteHeader(statusCode)
 				return
 			}
 		} else if r.Method == http.MethodPost {
-			response, statusCode = handlePostMockOMServer(t, r, requestMap)
+			By("receving a Post request to the OM server")
+			response, statusCode = handlePostMockOMServer(r, requestMap)
+			Expect(statusCode).ToNot(Equal(http.StatusInternalServerError))
 			if statusCode != 0 {
 				w.WriteHeader(statusCode)
 				return
 			}
-		} else if r.Method == http.MethodPut && r.RequestURI == "/v1/metadata/types/1" {
+		} else if r.Method == http.MethodPut {
+			By("receving a Put request to the OM server")
+			Expect(r.RequestURI).To(Equal("/v1/metadata/types/1"))
 			response = map[string]interface{}{}
-		} else if r.Method == http.MethodPatch && r.RequestURI == TablesURI+"/"+ZeroUUID {
+		} else if r.Method == http.MethodPatch {
+			By("receving a Patch request to the OM server")
+			Expect(r.RequestURI).To(Equal(TablesURI + "/" + ZeroUUID))
 			table, ok := mockDataCatalog[ZeroUUID].(*client.Table)
-			if !ok {
-				t.Fatalf("error: cannot find table")
-			}
+			Expect(ok).To(BeTrue())
 			ok = patchTable(table, requestArr)
-			if !ok {
-				t.Fatalf("error: table patch failed")
-			}
+			Expect(ok).To(BeTrue())
 			mockDataCatalog[ZeroUUID] = table
-
 			response = map[string]interface{}{}
-		} else {
-			t.Fatalf("unexpected request: %s -- %s", r.Method, r.RequestURI)
 		}
-
-		responseBytes := mustAsJSON(t, response)
-
+		responseBytes := mustAsJSON(response)
 		w.Header().Add(ContentType, ApplicationJSON)
 		_, err = w.Write(responseBytes)
-		if err != nil {
-			t.Error(err)
-		}
+		Expect(err).ToNot(HaveOccurred())
 	}))
 
 	return svr


### PR DESCRIPTION
the refactoring included adding the ginkgo syntax and structure as well as adjusting the flow of the tests to fit to ginkgo logic.

Main points to notice:
-  The setupSuite function was replaced with BeforeEach, making it a ginkgo set up node.
- Some of the documentation was replaced with description in the Describe and It functions.
Additionally, the By function was used to add more information for debugging and documentation, and its use can be expanded easily.

- The logging is mostly the same as before.